### PR TITLE
Convert CodableCloudPropertyValue & CodableUserDefaultsPropertyListValue to directly use Codable

### DIFF
--- a/AI_REFERENCE.md
+++ b/AI_REFERENCE.md
@@ -112,7 +112,7 @@ Both macros detect `@MainActor` attributes and generate appropriate isolation:
 ### UserDefaults Types
 - Basic: `String`, `Int`, `Bool`, `Double`, `Float`, `Data`, `URL`, `[String]`, `[Any]`
 - RawRepresentable: Enums with basic raw values
-- Codable: Custom types via `CodableUserDefaultsPropertyListValue`
+- Codable: Custom types via `Codable`
 - Optionals: All above types as optionals
 
 ### iCloud Types

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ class LocalStore {
     var people: People = .init(name: "fat", age: 10)
 }
 
-struct People: CodableUserDefaultsPropertyListValue {
+struct People: Codable {
     var name: String
     var age: Int
 }
@@ -397,7 +397,7 @@ class CloudStore {
     var userProfile: UserProfile = .init(name: "fat", preferences: .init())
 }
 
-struct UserProfile: CodableCloudPropertyListValue {
+struct UserProfile: Codable {
     var name: String
     var preferences: UserPreferences
 }

--- a/README_zh.md
+++ b/README_zh.md
@@ -383,7 +383,7 @@ class LocalStore {
     var people: People = .init(name: "fat", age: 10)
 }
 
-struct People: CodableUserDefaultsPropertyListValue {
+struct People: Codable {
     var name: String
     var age: Int
 }
@@ -397,7 +397,7 @@ class CloudStore {
     var userProfile: UserProfile = .init(name: "fat", preferences: .init())
 }
 
-struct UserProfile: CodableCloudPropertyListValue {
+struct UserProfile: Codable {
     var name: String
     var preferences: UserPreferences
 }

--- a/Sources/ObservableDefaults/Macros.swift
+++ b/Sources/ObservableDefaults/Macros.swift
@@ -183,7 +183,7 @@ public macro ObservableOnly() = #externalMacro(
 /// ```
 ///
 /// - Important: Can only be applied to classes, not structs
-/// - Note: Supports Codable types via CodableUserDefaultsPropertyListValue protocol
+/// - Note: Supports Codable types
 @attached(
     member,
     names: named(_$observationRegistrar),

--- a/Sources/ObservableDefaults/NSUbiquitousKeyValueStore/CloudPropertyListValue.swift
+++ b/Sources/ObservableDefaults/NSUbiquitousKeyValueStore/CloudPropertyListValue.swift
@@ -11,9 +11,6 @@ import Foundation
 /// Protocol for types that can be stored in NSUbiquitousKeyValueStore
 public protocol CloudPropertyListValue {}
 
-/// Protocol for Codable types that can be stored in NSUbiquitousKeyValueStore
-public protocol CodableCloudPropertyListValue: CloudPropertyListValue, Codable {}
-
 // Extensions for basic types supported by NSUbiquitousKeyValueStore
 extension String: CloudPropertyListValue {}
 extension Int: CloudPropertyListValue {}

--- a/Sources/ObservableDefaults/ObservableDefaults.docc/ObservableDefaults.md
+++ b/Sources/ObservableDefaults/ObservableDefaults.docc/ObservableDefaults.md
@@ -347,7 +347,7 @@ class CloudSettingsWithOptionals {
 
 #### UserDefaults with Codable
 
-For custom types with UserDefaults, implement `CodableUserDefaultsPropertyListValue`:
+For custom types with UserDefaults, implement `Codable`:
 
 ```swift
 @ObservableDefaults
@@ -355,7 +355,7 @@ class LocalStore {
     var people: People = .init(name: "fat", age: 10)
 }
 
-struct People: CodableUserDefaultsPropertyListValue {
+struct People: Codable {
     var name: String
     var age: Int
 }
@@ -363,7 +363,7 @@ struct People: CodableUserDefaultsPropertyListValue {
 
 #### Cloud Storage with Codable
 
-For custom types with cloud storage, implement `CodableCloudPropertyListValue`:
+For custom types with cloud storage, implement `Codable`:
 
 ```swift
 @ObservableCloud
@@ -371,7 +371,7 @@ class CloudStore {
     var userProfile: UserProfile = .init(name: "fat", preferences: .init())
 }
 
-struct UserProfile: CodableCloudPropertyListValue {
+struct UserProfile: Codable {
     var name: String
     var preferences: UserPreferences
 }

--- a/Sources/ObservableDefaults/UserDefaults/UserDefaultsPropertyListValue.swift
+++ b/Sources/ObservableDefaults/UserDefaults/UserDefaultsPropertyListValue.swift
@@ -32,12 +32,6 @@ import Foundation
 /// - Note: All conforming types must also be Equatable to support value comparison
 public protocol UserDefaultsPropertyListValue: Equatable {}
 
-/// A protocol that combines UserDefaultsPropertyListValue with Codable support.
-/// This allows custom types to be encoded/decoded as JSON and stored in UserDefaults.
-/// - Note: Types conforming to this protocol can be automatically serialized to Data
-///   and stored in UserDefaults using JSON encoding/decoding
-public protocol CodableUserDefaultsPropertyListValue: UserDefaultsPropertyListValue, Codable {}
-
 // MARK: - Data Types
 
 /// NSData conforms to UserDefaultsPropertyListValue as it's a fundamental property list type

--- a/Sources/ObservableDefaultsMacros/Macros/CloudBackedMacro.swift
+++ b/Sources/ObservableDefaultsMacros/Macros/CloudBackedMacro.swift
@@ -48,7 +48,7 @@ import SwiftSyntaxMacros
 /// - Property type must conform to appropriate protocols:
 ///   - `CloudPropertyListValue` for basic types (String, Int, Bool, etc.)
 ///   - `RawRepresentable` for enums with CloudPropertyListValue raw values
-///   - `CodableCloudPropertyListValue` for custom Codable types
+///   - `Codable` for custom Codable types
 ///
 /// ## Generated Code
 ///

--- a/Tests/ObservableDefaultsTests/CloudDirectCrashTest.swift
+++ b/Tests/ObservableDefaultsTests/CloudDirectCrashTest.swift
@@ -3,7 +3,7 @@ import ObservableDefaults
 import Testing
 
 // Test structures
-struct CloudCrashUser: Codable, CodableCloudPropertyListValue, Equatable {
+struct CloudCrashUser: Codable, Equatable {
     var name: String
     var age: Int
 }

--- a/Tests/ObservableDefaultsTests/CloudOptionalCodableTest.swift
+++ b/Tests/ObservableDefaultsTests/CloudOptionalCodableTest.swift
@@ -3,16 +3,16 @@ import ObservableDefaults
 import Testing
 
 // Test structures for Cloud
-struct CloudUser: Codable, CodableCloudPropertyListValue, Equatable {
+struct CloudUser: Codable, Equatable {
     var name: String
     var age: Int
 }
 
-struct CloudImage: Codable, CodableCloudPropertyListValue, Equatable {
+struct CloudImage: Codable, Equatable {
     var raw: Data
 }
 
-struct CloudUserWithImage: Codable, CodableCloudPropertyListValue, Equatable {
+struct CloudUserWithImage: Codable, Equatable {
     var name: String
     var image: CloudImage
 }

--- a/Tests/ObservableDefaultsTests/DirectOptionalCodableTest.swift
+++ b/Tests/ObservableDefaultsTests/DirectOptionalCodableTest.swift
@@ -3,7 +3,7 @@ import ObservableDefaults
 import Testing
 
 // Test the original issue directly
-struct DirectUser: Codable, CodableUserDefaultsPropertyListValue, Equatable {
+struct DirectUser: Codable, Equatable {
     var name: String
     var age: Int
 }

--- a/Tests/ObservableDefaultsTests/PrefixTests.swift
+++ b/Tests/ObservableDefaultsTests/PrefixTests.swift
@@ -85,5 +85,6 @@ func emptyParameters() {
 func emptyPrefixCloud() {
     let test = Test6()
     test.emptyPrefix = "updated"
+    let value = test.emptyPrefix == "updated"
     #expect(test.emptyPrefix == "updated")
 }

--- a/Tests/ObservableDefaultsTests/Utils/MockObject.swift
+++ b/Tests/ObservableDefaultsTests/Utils/MockObject.swift
@@ -152,7 +152,7 @@ class MockModelCloudKeyName {
 }
 
 /// Test Codable types
-struct FontStyle: CodableUserDefaultsPropertyListValue, CodableCloudPropertyListValue, Hashable, Identifiable {
+struct FontStyle: Codable, Hashable, Identifiable {
     let size: CGFloat
     let weight: Weight
     let id: Int


### PR DESCRIPTION
This builds on the existing work in #6 by tweaking it to remove the requirement to conform to a protocol other than Codable. This way, users don't need to import the framework and conform to the custom `Codable*PropertyListValue` in order to persist a Codable structure.

If the type conforms to CloudPropertyListValue or UserDefaultsPropertyListValue - the existing storage implementation is used. Only types that **don't** conform to *PropertyListValue but **do** conform to Codable use the Codable storage implementation (JSON encoding/decoding).

For example, previously one would have to write:

```swift
# MyStruct.swift
import ObservableDefaults

struct MyStruct: Codable {
  var foo: String
}

extension MyStruct: CodableUserDefaultsPropertyListValue {}

# Prefs.swift
import ObservableDefaults

@ObservableDefaults
class Prefs {
  var foo: Foo
}
```

This could now be written as:

```swift 
# MyStruct.swift
struct MyStruct: Codable {
  var foo: String
}

# Prefs.swift
import ObservableDefaults

@ObservableDefaults
class Prefs {
  var foo: Foo
}
```