### PR TITLE
Fix external change handler to correctly handle nil values

### DIFF
--- a/Tests/ObservableDefaultsTests/ExternalChangeEqualityTests.swift
+++ b/Tests/ObservableDefaultsTests/ExternalChangeEqualityTests.swift
@@ -64,4 +64,34 @@ struct ExternalChangeEqualityTests {
         try? await Task.sleep(nanoseconds: 100_000_000)
         #expect(model.name == "Test")
     }
+
+    // MARK: - Removing key (setting to nil) should trigger mutation
+
+    @Test("Removing key from UserDefaults triggers mutation back to default value")
+    func removingKeyTriggersMutation() {
+        let userDefaults = UserDefaults.getTestInstance(suiteName: #function)
+        let model = MockModel(userDefaults: userDefaults)
+
+        // Set a non-default value first
+        model.name = "Changed"
+
+        // Removing the key should trigger mutation (value reverts to default "Test")
+        tracking(model, \.name, .userDefaults)
+        userDefaults.removeObject(forKey: "name")
+        #expect(model.name == "Test")
+    }
+
+    @Test("Optional property: removing key triggers mutation back to nil")
+    func optionalRemovingKeyTriggersMutation() {
+        let userDefaults = UserDefaults.getTestInstance(suiteName: #function)
+        let model = MockModelOptional(userDefaults: userDefaults)
+
+        // Set a non-nil value first
+        model.optionalName = "Hello"
+
+        // Removing the key should trigger mutation (value reverts to nil)
+        tracking(model, \.optionalName, .userDefaults)
+        userDefaults.removeObject(forKey: "optionalName")
+        #expect(model.optionalName == nil)
+    }
 }


### PR DESCRIPTION
When UserDefaults key is removed (set to nil), use _default_value_of_ as fallback instead of current cached value. This ensures removed keys correctly revert to default without triggering spurious mutations.

Also distinguish between @DefaultsBacked (stored in UD) and @ObservableOnly (memory-only) properties - only apply equality check to backed properties that have _default_value_of_ storage.

Add tests for nil/removed key scenarios.