### PR TITLE
Allow swift-syntax 603.x

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "603.0.0"..<"604.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"605.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax", "600.0.0"..<"603.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax", "603.0.0"..<"604.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Updates the swift-syntax dependency range from 600.0.0..<603.0.0 to 603.0.0..<604.0.0.

This lets the package resolve with Swift 6.3 / Xcode 26.6, where the 602.x swift-syntax modules are no longer compiler-compatible. The package is already using Swift tools 6.0 and Swift language mode v6; this keeps the dependency pinned to the matching 603 release line rather than broadening across multiple swift-syntax major lines.